### PR TITLE
Update vfile to version 2.0.0 (with fixes and changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "dependencies": {
-    "vfile": "^1.1.0",
+    "vfile": "^2.0.0",
     "vinyl": "^1.1.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 'use strict'
-import path from 'path'
 import VFile from 'vfile'
 import Vinyl from 'vinyl'
 
@@ -23,15 +22,15 @@ module.exports = function (vinyl) {
     throw new TypeError('Expected a Vinyl file')
   }
 
-  const contents = newVinyl.contents.toString()
-  const directory = path.dirname(newVinyl.path)
-  const extension = path.extname(newVinyl.path).replace('.', '')
-  const filename = path.basename(newVinyl.path, `.${extension}`)
+  if (newVinyl.isStream()) {
+    throw new TypeError('Streams are not supported')
+  }
+
+  const contents = newVinyl.contents
+  const path = newVinyl.path
 
   return new VFile({
-    directory,
-    filename,
-    extension,
+    path,
     contents
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,20 +3,16 @@
 import convertVinylToVfile from '../lib/'
 import {expect} from 'chai'
 import {join} from 'path'
+import {Stream} from 'stream'
 import Vinyl from 'vinyl'
 
-describe('conver-vinyl-to-vfile', () => {
-  let directory, extension, filename, vinylFile
+describe('convert-vinyl-to-vfile', () => {
+  let vinylFile
 
   beforeEach(() => {
-    const contents = 'abe lincoln'
-    directory = join('users', 'dustin', 'project')
-    extension = 'md'
-    filename = 'awesome.project'
-
     vinylFile = new Vinyl({
-      contents: new Buffer(contents),
-      path: join(directory, `${filename}.${extension}`)
+      contents: new Buffer('abe lincoln'),
+      path: join('users', 'dustin', 'project', 'awesome.project.md')
     })
   })
 
@@ -26,6 +22,16 @@ describe('conver-vinyl-to-vfile', () => {
     expect(test).to.throw(TypeError, /Expected a Vinyl file/)
   })
 
+  it('should throw error if vinyl is a stream', () => {
+    const file = new Vinyl({
+      contents: new Stream(),
+      path: 'awesome.project.md'
+    })
+    const test = () => convertVinylToVfile(file)
+
+    expect(test).to.throw(TypeError, /Streams are not supported/)
+  })
+
   describe('output', () => {
     let result
 
@@ -33,20 +39,20 @@ describe('conver-vinyl-to-vfile', () => {
       result = convertVinylToVfile(vinylFile)
     })
 
-    it('should have a directory property', () => {
-      expect(result.directory).to.eql(directory)
+    it('should have a dirname property', () => {
+      expect(result.dirname).to.eql(vinylFile.dirname)
     })
 
-    it('should have a filename property', () => {
-      expect(result.filename).to.eql(filename)
+    it('should have a stem property', () => {
+      expect(result.stem).to.eql(vinylFile.stem)
     })
 
-    it('should have an extension property', () => {
-      expect(result.extension).to.eql(extension)
+    it('should have an extname property', () => {
+      expect(result.extname).to.eql(vinylFile.extname)
     })
 
-    it('should have a contents property', () => {
-      expect(result.contents).to.eql('abe lincoln')
+    it('should have contents', () => {
+      expect(result.toString()).to.eql(vinylFile.contents.toString())
     })
   })
 })


### PR DESCRIPTION
- vfile now looks more like vinyl, so the checks are simpler;
- added explicit error on a streaming vinyl;
- Prefer buffers over strings.
