### PR TITLE
Forward data property from vinyl file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ module.exports = function (vinyl) {
 
   return new VFile({
     path,
-    contents
+    contents,
+    data: newVinyl.data
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,8 @@ describe('convert-vinyl-to-vfile', () => {
   beforeEach(() => {
     vinylFile = new Vinyl({
       contents: new Buffer('abe lincoln'),
-      path: join('users', 'dustin', 'project', 'awesome.project.md')
+      path: join('users', 'dustin', 'project', 'awesome.project.md'),
+      data: {custom: 'data'}
     })
   })
 
@@ -53,6 +54,10 @@ describe('convert-vinyl-to-vfile', () => {
 
     it('should have contents', () => {
       expect(result.toString()).to.eql(vinylFile.contents.toString())
+    })
+
+    it('should have custom data', () => {
+      expect(result.data).to.eql(vinylFile.data)
     })
   })
 })


### PR DESCRIPTION
Attaching custom data to `vinyl.data` has been somewhat standardized by [gulp-data](https://www.npmjs.com/package/gulp-data), so forwarding this property to vfile will make this data available to unified plugins.

unifiedjs/unified-engine-gulp#20
