### PR TITLE
Only forward data from vinyl if defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,14 @@ module.exports = function (vinyl) {
     throw new TypeError('Streams are not supported')
   }
 
-  const contents = newVinyl.contents
-  const path = newVinyl.path
+  const options = {}
 
-  return new VFile({
-    path,
-    contents,
-    data: newVinyl.data
-  })
+  options.contents = newVinyl.contents
+  options.path = newVinyl.path
+
+  if (typeof newVinyl.data !== 'undefined') {
+    options.data = newVinyl.data
+  }
+
+  return new VFile(options)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ import {expect} from 'chai'
 import {join} from 'path'
 import {Stream} from 'stream'
 import Vinyl from 'vinyl'
+import VFile from 'vfile'
 
 describe('convert-vinyl-to-vfile', () => {
   let vinylFile
@@ -58,6 +59,13 @@ describe('convert-vinyl-to-vfile', () => {
 
     it('should have custom data', () => {
       expect(result.data).to.eql(vinylFile.data)
+    })
+
+    it('should have default data if not defined', () => {
+      const plainVinyl = new Vinyl({path: 'plain.txt'})
+      const plainVfile = new VFile({path: 'plain.txt'})
+      const defaultData = plainVfile.data
+      expect(convertVinylToVfile(plainVinyl).data).to.deep.eql(defaultData)
     })
   })
 })


### PR DESCRIPTION
By default `vfile.data` is an empty object. However, if `undefined` is passed as `data` when creating a vfile, it becomes `undefined` instead, which causes errors in libraries like unified-engine which count on it being an object.
